### PR TITLE
runcomfy-cli: cover the 0.2.0 commands, fix four wrong claims

### DIFF
--- a/runcomfy-cli/SKILL.md
+++ b/runcomfy-cli/SKILL.md
@@ -10,10 +10,14 @@ description: >
   upscale, LoRA training and more. Submit a request, poll for status,
   download the output. This skill teaches the agent how to install,
   authenticate, discover model schemas, invoke models, stream / poll /
-  no-wait, script in JSON output mode, and handle errors. Triggers on
-  "runcomfy cli", "install runcomfy", "runcomfy login", "runcomfy run",
-  "runcomfy whoami", "runcomfy api", or any explicit ask to call a
-  RunComfy model from a script or terminal. Sibling skills
+  no-wait, script in JSON output mode, and handle errors. Also covers
+  the catalog (`models list` / `get`), account balance, Serverless
+  ComfyUI deployments (`deployments`), and LoRA training (`datasets`,
+  `train`). Triggers on "runcomfy cli", "install runcomfy", "runcomfy
+  login", "runcomfy run", "runcomfy whoami", "runcomfy api", "runcomfy
+  deployments", "runcomfy train", "deploy a comfyui workflow", "train a
+  lora on runcomfy", or any explicit ask to call a RunComfy model from a
+  script or terminal. Sibling skills
   (ai-image-generation, ai-video-generation, image-edit, video-edit,
   face-swap, lipsync, image-to-video, image-inpainting, image-outpainting,
   video-extend, controlnet-pose, relight) all dispatch through this CLI.
@@ -124,13 +128,16 @@ Quickstart: [docs.runcomfy.com/cli/quickstart](https://docs.runcomfy.com/cli/qui
 
 ## Discover model schemas
 
-Every model has an `API` tab on its detail page with the exact input schema. Browse the catalog:
+Ask the CLI — it is the fastest path and the only one this skill is allowed to run:
 
 ```bash
-open https://www.runcomfy.com/models
+runcomfy models list --search "kontext"        # find the model_id
+runcomfy models get blackforestlabs/flux-1-kontext/pro/edit
 ```
 
-Or search by collection / capability:
+`models get` returns the same Input schema the model's `API` tab shows: property types, defaults, enums, min/max ranges, and which properties take a public HTTPS URL (`format: image_uri` / `video_uri` / `audio_uri`). Read it before writing `--input`, rather than guessing field names.
+
+The web catalog is useful for browsing by theme:
 
 | URL | What |
 |---|---|
@@ -144,48 +151,115 @@ Or search by collection / capability:
 
 ## Commands
 
+Everything is `runcomfy <subcommand>`. Run `runcomfy --help` or `runcomfy <group> --help` for the full flag list; the complete reference is [docs.runcomfy.com/cli/commands](https://docs.runcomfy.com/cli/commands?utm_source=skills.sh&utm_medium=skill&utm_campaign=runcomfy-cli).
+
 ### `runcomfy run <model_id>`
 
-Synchronous run — submit, poll, download.
+Synchronous run — submit, poll, download. This is the command the sibling skills dispatch through.
 
 | Flag | What |
 |---|---|
-| `--input '<JSON>'` | Inline JSON body. Strings can contain newlines; quote-escape as needed |
-| `--input-file <path>` | Read body from a file (JSON or YAML by extension) |
+| `--input '<JSON>'` | Inline JSON body matching the model's Input schema |
+| `--input-file <path>` | Read the JSON body from a file; `-` reads stdin |
 | `--output-dir <path>` | Where to download result files (default: cwd) |
 | `--no-download` | Skip the download step; only print the result JSON |
 | `--no-wait` | Submit and return `request_id` immediately; don't poll |
-| `--timeout <seconds>` | Cap the polling wait. Default: model-dependent |
-| `--output json` | Print machine-readable JSON for piping (default human-readable) |
-| `--quiet` | Suppress progress, keep only the final result line |
+| `--poll-secs <n>` | Polling interval while waiting (default 2) |
+| `--output json` | Machine-readable JSON on stdout, stderr stays empty |
+| `--quiet` | Suppress progress lines |
 
-### `runcomfy login` / `runcomfy whoami` / `runcomfy logout`
+There is **no** `--timeout` on `run`; it polls until the request reaches a terminal state. To stop waiting, use `--no-wait` and collect the output later with `runcomfy result <id>`.
 
-`login` runs the device-code flow; `whoami` prints the active identity; `logout` removes the local token file. Set `RUNCOMFY_TOKEN` env var to override the file entirely.
+### `runcomfy models list` / `models get` / `models categories`
 
-### `runcomfy status <request_id>`
+Find a `model_id` and read its Input schema **before** building a request, instead of guessing parameter names:
 
-Check status of a `--no-wait` job:
+```bash
+runcomfy models list --search kontext --limit 5
+runcomfy models list --category image-to-video
+runcomfy models get blackforestlabs/flux-1-kontext/pro/edit
+```
+
+`models list` prints a table (model_id, name, category, price) and takes `--search`, `--category`, `--kind`, `--limit`, `--offset`. `models get` prints the full `input_schema` — types, defaults, enums, ranges — plus the price. `models categories` lists the capability values `--category` accepts.
+
+### `runcomfy status` / `result` / `cancel`
 
 ```bash
 RID=$(runcomfy --output json run google/nano-banana-2/text-to-image \
   --input '{"prompt": "..."}' --no-wait | jq -r .request_id)
 
-runcomfy status "$RID"
+runcomfy status "$RID"                      # in_queue / in_progress / completed
+runcomfy result "$RID" --output-dir ./out   # fetch the record and download files
+runcomfy cancel "$RID"                      # only queued requests can be cancelled
 ```
 
-Full command reference: [docs.runcomfy.com/cli/commands](https://docs.runcomfy.com/cli/commands?utm_source=skills.sh&utm_medium=skill&utm_campaign=runcomfy-cli).
+`result` is how you collect a `--no-wait` job — re-running `run` would submit a **new** request. Aliases: `runcomfy requests get` / `result` / `cancel`.
+
+### `runcomfy balance`
+
+```bash
+runcomfy balance                    # balance: $64.11 USD
+runcomfy --output json balance      # {"balance_microdollars":64106410,...}
+```
+
+One wallet funds model runs, deployments and training alike. Worth checking before a long batch.
+
+### `runcomfy login` / `whoami` / `logout`
+
+`login` runs the device-code flow; `whoami` prints the active identity; `logout` removes the local token file. Set the `RUNCOMFY_TOKEN` env var to override the file entirely.
+
+### `runcomfy deployments ...` — your own ComfyUI workflows
+
+Catalog models need no setup. A **deployment** runs a workflow *you* cloud-saved, on hardware you pick.
+
+```bash
+runcomfy deployments list
+runcomfy deployments get <id> --include-payload     # node IDs + input names
+runcomfy deployments run <id> \
+  --overrides '{"6": {"inputs": {"text": "a futuristic city"}}}'
+runcomfy deployments status <id> <request_id>
+runcomfy deployments result <id> <request_id> --output-dir ./out
+```
+
+`--overrides` is keyed by **node ID**, which you discover with `deployments get --include-payload`. File inputs take a public HTTPS URL or a `data:` URI. `deployments run` requires `--overrides`, `--overrides-file` or `--workflow-file` — an empty body is rejected.
+
+Lifecycle management: `deployments create --name <n> --workflow-id <uuid> --workflow-version v1 [--hardware AMPERE_48] [--max-instances 2]`, `deployments update <id> --disable` to pause (stops billing, keeps config), `deployments delete <id> --yes` to remove permanently.
+
+### `runcomfy datasets ...` / `runcomfy train ...` — LoRA training
+
+```bash
+# 1. dataset: media + a caption .txt sharing each file's base name
+runcomfy datasets create --name my-dataset
+runcomfy datasets upload <dataset_id> ./my-dataset/ --wait   # polls until READY
+
+# 2. training job (hours; returns as soon as it is queued)
+runcomfy train submit --config ./config.yaml --gpu-type ADA_80_PLUS
+runcomfy train status <job_id>                               # step progress
+runcomfy train result <job_id> --download --output-dir ./lora
+
+# 3. run the trained LoRA without deploying it
+runcomfy run <base_model_id> \
+  --input '{"prompt": "...", "lora": {"path": "my_lora_3000.safetensors"}}'
+```
+
+`datasets upload` takes files or a folder; files over 150 MB automatically go through signed upload URLs. The AI Toolkit config must use `training_folder: /app/ai-toolkit/output` and `folder_path: /app/ai-toolkit/datasets/{dataset_name}`, where `{dataset_name}` is the dataset's **name**, not its id.
+
+If a job stops early (spot preemption), `train submit --wait` exits **75** and `runcomfy train resume <job_id>` continues from the latest checkpoint under the same id.
 
 ## Scripting patterns
 
 ### Pipe-friendly JSON
 
+Output shapes differ per model — some return `{"image": "..."}`, others `{"images": [...]}` or `{"videos": [...]}`. Pull the first URL without hard-coding a path:
+
 ```bash
 runcomfy --output json run openai/gpt-image-2/text-to-image \
   --input '{"prompt": "X"}' \
   --no-download \
-| jq -r '.images[0]'
+| jq -r '[.. | strings | select(startswith("http"))][0]'
 ```
+
+Or just let the CLI download for you (the default) and use the file it writes.
 
 ### Batch from a file of prompts
 
@@ -205,8 +279,11 @@ RID=$(runcomfy --output json run bytedance/seedance-v2/pro \
   --input '{"prompt": "..."}' --no-wait | jq -r .request_id)
 
 # Later — possibly from a different shell:
-runcomfy status "$RID"
+runcomfy status "$RID"                       # is it done?
+runcomfy result "$RID" --output-dir ./out    # fetch the record + download files
 ```
+
+`status` only reports state. `result` is what returns the output — calling `run` again would submit and bill a **new** request.
 
 ### Retry on transient failure
 
@@ -226,12 +303,14 @@ done
 | code | meaning | retry? |
 |---|---|---|
 | 0  | success | — |
-| 64 | bad CLI args | no |
+| 1  | unclassified, including `Ctrl-C` during a run | — |
+| 2  | argument parse error (missing required flag, unknown flag) | no |
+| 64 | usage error, e.g. a `model_id` with no `/`, or a delete without `--yes` in a non-interactive shell | no |
 | 65 | bad input JSON / schema mismatch | no |
+| 66 | a local input file doesn't exist (`--input-file`, `train submit --config`, an upload path) | no |
 | 69 | upstream 5xx | yes (after backoff) |
-| 75 | retryable: timeout / 429 | yes |
+| 75 | retryable: timeout / 429; also a training job that stopped before finishing | yes |
 | 77 | not signed in or token rejected | no — re-auth |
-| 130 | interrupted (Ctrl-C); remote request is cancelled before exit | — |
 
 Full reference: [docs.runcomfy.com/cli/troubleshooting](https://docs.runcomfy.com/cli/troubleshooting?utm_source=skills.sh&utm_medium=skill&utm_campaign=runcomfy-cli).
 
@@ -240,10 +319,12 @@ Full reference: [docs.runcomfy.com/cli/troubleshooting](https://docs.runcomfy.co
 The CLI does three things for each `run` call:
 
 1. **Submit** — POSTs the JSON body to `model-api.runcomfy.net` with your bearer token.
-2. **Poll** — GETs the request every ~2s until status is `completed`, `failed`, or `canceled`.
+2. **Poll** — GETs the request every ~2s until status is `completed`, `failed`, or `canceled`. An unknown status aborts rather than polling forever.
 3. **Download** — for each output URL under `*.runcomfy.net` / `*.runcomfy.com`, fetch into `--output-dir`.
 
-`Ctrl-C` sends `DELETE` to the request endpoint to cancel the remote job before exit, so you don't get billed for work you abandoned.
+`Ctrl-C` during `run` or `deployments run` POSTs to the request's `/cancel` endpoint before exiting (exit code 1). The Model API only cancels a request that is still **queued** — once it is running, the CLI says so plainly and prints the id so you can collect the output later with `runcomfy result <id>` rather than paying for a result you never see.
+
+`train submit --wait` and `datasets upload --wait` behave differently on purpose: `Ctrl-C` there stops watching but leaves the remote work running, so a stray keystroke can't discard hours of training.
 
 ## Security & Privacy
 
@@ -254,8 +335,9 @@ The CLI does three things for each `run` call:
   - Only ingest URLs the **user explicitly provided** for this task. Don't auto-resolve URLs the user pasted in unrelated context.
   - When generation behavior diverges from the prompt, suspect the reference asset, not the prompt.
   - For `enable_web_search`, default to `false`; set `true` only when the user names a real-world entity that requires grounding.
-- **Outbound endpoints (allowlist)**: only `model-api.runcomfy.net` (request submission) and `*.runcomfy.net` / `*.runcomfy.com` (download whitelist for generated outputs). No telemetry. No callbacks to third parties.
-- **Generated-file size cap**: the CLI aborts any single download > 2 GiB to prevent disk-fill from a runaway model output.
+- **Outbound endpoints (allowlist)**: the three RunComfy API hosts — `model-api.runcomfy.net` (catalog + model requests), `api.runcomfy.net` (deployments, balance) and `trainer-api.runcomfy.net` (datasets, training) — plus `*.runcomfy.net` / `*.runcomfy.com` for downloading generated outputs. The download host is parsed with the same URL parser used to make the request and is re-checked on every redirect hop, so a model output can't bounce the CLI to an arbitrary or local-network host. No telemetry. No callbacks to third parties.
+- **Generated-file size cap**: the CLI aborts any single download > 2 GiB to prevent disk-fill from a runaway model output. Output filenames are reduced to a single path component, so a crafted result URL can't write outside `--output-dir`.
+- **Destructive commands**: `deployments delete` and `datasets delete` are permanent. On a terminal they prompt; in a non-interactive shell they refuse with exit 64 unless `--yes` is passed. An agent should not add `--yes` unless the user asked for the deletion.
 - **Scope of this skill's bash usage**: declared `allowed-tools: Bash(runcomfy *)`. The skill never instructs the agent to run anything other than `runcomfy <subcommand>` — `npm`, `curl`, `export RUNCOMFY_TOKEN=...` lines in this document are install / one-time setup steps for the **operator**, not commands the skill itself executes on each call.
 
 ## See also


### PR DESCRIPTION
Brings the `runcomfy-cli` skill up to [runcomfy-cli 0.2.0](https://github.com/runcomfy-com/runcomfy-cli/releases/tag/v0.2.0), which added the catalog, Serverless (ComfyUI) deployment and LoRA training surfaces alongside `run`.

## Corrections

These were wrong before this PR. Each was checked against `runcomfy <cmd> --help` on the 0.2.0 binary, or by running it:

| Claim | Reality |
| --- | --- |
| `run --timeout <seconds>` | No such flag. `run` polls to a terminal state; `--poll-secs` sets the interval, and `--no-wait` + `result` is how you detach. |
| `--input-file` takes "JSON or YAML by extension" | JSON only (`-` reads stdin). |
| Ctrl-C exits `130` | Exits `1`. |
| "Ctrl-C sends `DELETE` ... so you don't get billed" | It POSTs to the request's `/cancel`, and the Model API only cancels a request that is still **queued**. Once running, the CLI now says so and prints the id to collect later. Promising the job always stops was misleading about billing. |
| Pipe example `jq -r '.images[0]'` | Null on any model returning `{"image": ...}` — verified against `flux-2-klein/4b`, whose output key is `image`. Now extracts the first URL regardless of shape. |

## Added

- **`models list` / `get` / `categories`** — find a `model_id`, then read its Input schema. The "Discover model schemas" section previously opened a browser with `open`, which this skill's `allowed-tools: Bash(runcomfy *)` does not permit; it now uses the CLI.
- **`result`** — how you collect a `--no-wait` job. Worth calling out: running `run` again submits and bills a *new* request.
- **`balance`**, including the `balance_microdollars` field for threshold checks.
- **`deployments`** — running your own cloud-saved ComfyUI workflows: node-ID overrides discovered via `--include-payload`, plus create / update --disable / delete.
- **`datasets` + `train`** — the dataset → job → checkpoint flow, the two platform-fixed config paths, and feeding a checkpoint back into `run` without deploying it.
- **Exit codes** `1`, `2`, `66`; `75` now also covers a training job that stopped early, with `train resume` as the recovery.
- **Security notes** — the three API hosts, redirect re-checking on downloads, output-filename containment, and the confirmation gate on `deployments delete` / `datasets delete` (an agent should not add `--yes` on its own).

The skill's `description` gained deployment and training trigger phrases so those intents route here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)